### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/FMPFeedbackForm.podspec
+++ b/FMPFeedbackForm.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => "https://github.com/MacPaw/FMPFeedbackForm.git", :tag => "v#{spec.version}" }
 
   spec.source_files  = "FMPFeedbackForm/**/*.{h,m}"
+  spec.exclude_files = "FMPFeedbackForm/include/**"
   spec.resources = "FMPFeedbackForm/Resources/*"
   spec.requires_arc = true
 

--- a/FMPFeedbackForm.xcodeproj/xcshareddata/xcschemes/FMPFeedbackForm.xcscheme
+++ b/FMPFeedbackForm.xcodeproj/xcshareddata/xcschemes/FMPFeedbackForm.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2FD1526923D6DD6D00EE0BC2"
+               BuildableName = "FMPFeedbackForm.framework"
+               BlueprintName = "FMPFeedbackForm"
+               ReferencedContainer = "container:FMPFeedbackForm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2FD1526923D6DD6D00EE0BC2"
+            BuildableName = "FMPFeedbackForm.framework"
+            BlueprintName = "FMPFeedbackForm"
+            ReferencedContainer = "container:FMPFeedbackForm.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FMPFeedbackForm/FMPFeedbackForm.h
+++ b/FMPFeedbackForm/FMPFeedbackForm.h
@@ -6,8 +6,16 @@
 //  Copyright © 2020 MacPaw. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
 #import "FMPFeedbackParameter.h"
 #import "FMPFeedbackSender.h"
 #import "FMPZendeskFeedbackSender.h"
 #import "FMPFeedbackController.h"
 #import "FMPInterfaceSettings.h"
+#else
+#import <FMPFeedbackForm/FMPFeedbackParameter.h>
+#import <FMPFeedbackForm/FMPFeedbackSender.h>
+#import <FMPFeedbackForm/FMPZendeskFeedbackSender.h>
+#import <FMPFeedbackForm/FMPFeedbackController.h>
+#import <FMPFeedbackForm/FMPInterfaceSettings.h>
+#endif

--- a/FMPFeedbackForm/FMPFeedbackForm.h
+++ b/FMPFeedbackForm/FMPFeedbackForm.h
@@ -6,8 +6,8 @@
 //  Copyright © 2020 MacPaw. All rights reserved.
 //
 
-#import <FMPFeedbackForm/FMPFeedbackParameter.h>
-#import <FMPFeedbackForm/FMPFeedbackSender.h>
-#import <FMPFeedbackForm/FMPZendeskFeedbackSender.h>
-#import <FMPFeedbackForm/FMPFeedbackController.h>
-#import <FMPFeedbackForm/FMPInterfaceSettings.h>
+#import "FMPFeedbackParameter.h"
+#import "FMPFeedbackSender.h"
+#import "FMPZendeskFeedbackSender.h"
+#import "FMPFeedbackController.h"
+#import "FMPInterfaceSettings.h"

--- a/FMPFeedbackForm/Sources/Extensions/NSColor+FMPExtensions.m
+++ b/FMPFeedbackForm/Sources/Extensions/NSColor+FMPExtensions.m
@@ -70,11 +70,7 @@
 {
     if (@available(macOS 10.13, *))
     {
-#if SWIFT_PACKAGE
-        return [NSColor colorNamed:colorName bundle:SWIFTPM_MODULE_BUNDLE];
-#else
         return [NSColor colorNamed:colorName bundle:FMPBundleHelper.currentBundle];
-#endif
     }
     else
     {

--- a/FMPFeedbackForm/Sources/Extensions/NSColor+FMPExtensions.m
+++ b/FMPFeedbackForm/Sources/Extensions/NSColor+FMPExtensions.m
@@ -70,7 +70,11 @@
 {
     if (@available(macOS 10.13, *))
     {
+#if SWIFT_PACKAGE
+        return [NSColor colorNamed:colorName bundle:SWIFTPM_MODULE_BUNDLE];
+#else
         return [NSColor colorNamed:colorName bundle:FMPBundleHelper.currentBundle];
+#endif
     }
     else
     {

--- a/FMPFeedbackForm/Sources/Extensions/NSImage+FMPExtensions.m
+++ b/FMPFeedbackForm/Sources/Extensions/NSImage+FMPExtensions.m
@@ -13,7 +13,11 @@
 
 + (instancetype)fmp_imageNamed:(NSString *)imageName
 {
+#if SWIFT_PACKAGE
+    return [SWIFTPM_MODULE_BUNDLE imageForResource:imageName];
+#else
     return [FMPBundleHelper.currentBundle imageForResource:imageName];
+#endif
 }
 
 - (NSImage *)fmp_maskedImageWithColor:(NSColor *)color

--- a/FMPFeedbackForm/Sources/Extensions/NSImage+FMPExtensions.m
+++ b/FMPFeedbackForm/Sources/Extensions/NSImage+FMPExtensions.m
@@ -13,11 +13,7 @@
 
 + (instancetype)fmp_imageNamed:(NSString *)imageName
 {
-#if SWIFT_PACKAGE
-    return [SWIFTPM_MODULE_BUNDLE imageForResource:imageName];
-#else
     return [FMPBundleHelper.currentBundle imageForResource:imageName];
-#endif
 }
 
 - (NSImage *)fmp_maskedImageWithColor:(NSColor *)color

--- a/FMPFeedbackForm/Sources/Model/FeedbackSender/FMPFeedbackSender.h
+++ b/FMPFeedbackForm/Sources/Model/FeedbackSender/FMPFeedbackSender.h
@@ -7,7 +7,7 @@
 //
 
 @import Foundation;
-#import <FMPFeedbackForm/FMPFeedbackParameter.h>
+#import "FMPFeedbackParameter.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Model/FeedbackSender/FMPZendeskFeedbackSender.h
+++ b/FMPFeedbackForm/Sources/Model/FeedbackSender/FMPZendeskFeedbackSender.h
@@ -7,7 +7,7 @@
 //
 
 @import Foundation;
-#import <FMPFeedbackForm/FMPFeedbackSender.h>
+#import "FMPFeedbackSender.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Model/FileSelectionManager/FMPDefaultFileSelectionManager.h
+++ b/FMPFeedbackForm/Sources/Model/FileSelectionManager/FMPDefaultFileSelectionManager.h
@@ -7,7 +7,7 @@
 //
 
 @import Cocoa;
-#import <FMPFeedbackForm/FMPFileSelectionManager.h>
+#import "FMPFileSelectionManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Model/Settings/FMPInterfaceSettings+ObservableProperties.h
+++ b/FMPFeedbackForm/Sources/Model/Settings/FMPInterfaceSettings+ObservableProperties.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 MacPaw. All rights reserved.
 //
 
-#import <FMPFeedbackForm/FMPFeedbackForm.h>
+#import "FMPFeedbackForm.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Model/SystemProfileProvider/FMPDefaultSystemProfileProvider.h
+++ b/FMPFeedbackForm/Sources/Model/SystemProfileProvider/FMPDefaultSystemProfileProvider.h
@@ -7,7 +7,7 @@
 //
 
 @import Foundation;
-#import <FMPFeedbackForm/FMPSystemProfileProvider.h>
+#import "FMPSystemProfileProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Utilities/FMPBundleHelper.m
+++ b/FMPFeedbackForm/Sources/Utilities/FMPBundleHelper.m
@@ -15,7 +15,11 @@
     static NSBundle *bundle = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+#if SWIFT_PACKAGE
+        bundle = SWIFTPM_MODULE_BUNDLE;
+#else
         bundle = [NSBundle bundleForClass:[self class]];
+#endif
     });
     
     return bundle;

--- a/FMPFeedbackForm/Sources/Utilities/FMPLocalizedString.m
+++ b/FMPFeedbackForm/Sources/Utilities/FMPLocalizedString.m
@@ -11,5 +11,9 @@
 
 NSString *FMPLocalizedString(NSString *key, NSString *comment)
 {
+#if SWIFT_PACKAGE
+    return [SWIFTPM_MODULE_BUNDLE localizedStringForKey:key value:key table:nil];
+#else
     return [FMPBundleHelper.currentBundle localizedStringForKey:key value:key table:nil];
+#endif
 }

--- a/FMPFeedbackForm/Sources/Utilities/FMPLocalizedString.m
+++ b/FMPFeedbackForm/Sources/Utilities/FMPLocalizedString.m
@@ -11,9 +11,5 @@
 
 NSString *FMPLocalizedString(NSString *key, NSString *comment)
 {
-#if SWIFT_PACKAGE
-    return [SWIFTPM_MODULE_BUNDLE localizedStringForKey:key value:key table:nil];
-#else
     return [FMPBundleHelper.currentBundle localizedStringForKey:key value:key table:nil];
-#endif
 }

--- a/FMPFeedbackForm/Sources/ViewControllers/FMPMainViewController.h
+++ b/FMPFeedbackForm/Sources/ViewControllers/FMPMainViewController.h
@@ -8,9 +8,9 @@
 
 @import Cocoa;
 @protocol FMPFileSelectionManager;
-#import <FMPFeedbackForm/FMPInterfaceSettings.h>
-#import <FMPFeedbackForm/FMPFeedbackSender.h>
-#import <FMPFeedbackForm/FMPSystemProfileProvider.h>
+#import "FMPInterfaceSettings.h"
+#import "FMPFeedbackSender.h"
+#import "FMPSystemProfileProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Views/TextControls/FMPTextControlValidationContainer.h
+++ b/FMPFeedbackForm/Sources/Views/TextControls/FMPTextControlValidationContainer.h
@@ -7,7 +7,7 @@
 //
 
 #import "FMPTextField.h"
-#import <FMPFeedbackForm/FMPTextControl.h>
+#import "FMPTextControl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Views/TextControls/FMPTextField.h
+++ b/FMPFeedbackForm/Sources/Views/TextControls/FMPTextField.h
@@ -7,7 +7,7 @@
 //
 
 @import Cocoa;
-#import <FMPFeedbackForm/FMPTextControl.h>
+#import "FMPTextControl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Views/TextControls/FMPTextFieldWrapper.h
+++ b/FMPFeedbackForm/Sources/Views/TextControls/FMPTextFieldWrapper.h
@@ -8,7 +8,7 @@
 
 @import Cocoa;
 @class FMPTextField;
-#import <FMPFeedbackForm/FMPTextControl.h>
+#import "FMPTextControl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Views/TextControls/FMPTextView.h
+++ b/FMPFeedbackForm/Sources/Views/TextControls/FMPTextView.h
@@ -7,7 +7,7 @@
 //
 
 @import Cocoa;
-#import <FMPFeedbackForm/FMPTextControl.h>
+#import "FMPTextControl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Views/TextControls/FMPTextViewScroller.h
+++ b/FMPFeedbackForm/Sources/Views/TextControls/FMPTextViewScroller.h
@@ -8,7 +8,7 @@
 
 @import Cocoa;
 @class FMPTextView;
-#import <FMPFeedbackForm/FMPTextControl.h>
+#import "FMPTextControl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/Sources/Views/TextControls/FMPValidatableTextControlContainer.h
+++ b/FMPFeedbackForm/Sources/Views/TextControls/FMPValidatableTextControlContainer.h
@@ -7,7 +7,7 @@
 //
 
 #import "FMPTextField.h"
-#import <FMPFeedbackForm/FMPTextControl.h>
+#import "FMPTextControl.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FMPFeedbackForm/include/FMPAttachButtonItem.h
+++ b/FMPFeedbackForm/include/FMPAttachButtonItem.h
@@ -1,0 +1,1 @@
+../Sources/Views/AttachmentItems/FMPAttachButtonItem.h

--- a/FMPFeedbackForm/include/FMPAttachmentItem.h
+++ b/FMPFeedbackForm/include/FMPAttachmentItem.h
@@ -1,0 +1,1 @@
+../Sources/Views/AttachmentItems/FMPAttachmentItem.h

--- a/FMPFeedbackForm/include/FMPAttachmentsCollectionView.h
+++ b/FMPFeedbackForm/include/FMPAttachmentsCollectionView.h
@@ -1,0 +1,1 @@
+../Sources/Views/FMPAttachmentsCollectionView.h

--- a/FMPFeedbackForm/include/FMPAttachmentsViewController.h
+++ b/FMPFeedbackForm/include/FMPAttachmentsViewController.h
@@ -1,0 +1,1 @@
+../Sources/ViewControllers/FMPAttachmentsViewController.h

--- a/FMPFeedbackForm/include/FMPBorderedView.h
+++ b/FMPFeedbackForm/include/FMPBorderedView.h
@@ -1,0 +1,1 @@
+../Sources/Views/FMPBorderedView.h

--- a/FMPFeedbackForm/include/FMPBundleHelper.h
+++ b/FMPFeedbackForm/include/FMPBundleHelper.h
@@ -1,0 +1,1 @@
+../Sources/Utilities/FMPBundleHelper.h

--- a/FMPFeedbackForm/include/FMPClickableView.h
+++ b/FMPFeedbackForm/include/FMPClickableView.h
@@ -1,0 +1,1 @@
+../Sources/Views/FMPClickableView.h

--- a/FMPFeedbackForm/include/FMPClipView.h
+++ b/FMPFeedbackForm/include/FMPClipView.h
@@ -1,0 +1,1 @@
+../Sources/Views/TextControls/FMPClipView.h

--- a/FMPFeedbackForm/include/FMPDefaultFileSelectionManager.h
+++ b/FMPFeedbackForm/include/FMPDefaultFileSelectionManager.h
@@ -1,0 +1,1 @@
+../Sources/Model/FileSelectionManager/FMPDefaultFileSelectionManager.h

--- a/FMPFeedbackForm/include/FMPDefaultSystemProfileProvider.h
+++ b/FMPFeedbackForm/include/FMPDefaultSystemProfileProvider.h
@@ -1,0 +1,1 @@
+../Sources/Model/SystemProfileProvider/FMPDefaultSystemProfileProvider.h

--- a/FMPFeedbackForm/include/FMPFeedbackController.h
+++ b/FMPFeedbackForm/include/FMPFeedbackController.h
@@ -1,0 +1,1 @@
+../Sources/WindowController/FMPFeedbackController.h

--- a/FMPFeedbackForm/include/FMPFeedbackForm.h
+++ b/FMPFeedbackForm/include/FMPFeedbackForm.h
@@ -1,0 +1,1 @@
+../FMPFeedbackForm.h

--- a/FMPFeedbackForm/include/FMPFeedbackParameter.h
+++ b/FMPFeedbackForm/include/FMPFeedbackParameter.h
@@ -1,0 +1,1 @@
+../Sources/Model/FeedbackSender/FMPFeedbackParameter.h

--- a/FMPFeedbackForm/include/FMPFeedbackSender.h
+++ b/FMPFeedbackForm/include/FMPFeedbackSender.h
@@ -1,0 +1,1 @@
+../Sources/Model/FeedbackSender/FMPFeedbackSender.h

--- a/FMPFeedbackForm/include/FMPFileSelectionManager.h
+++ b/FMPFeedbackForm/include/FMPFileSelectionManager.h
@@ -1,0 +1,1 @@
+../Sources/Model/FileSelectionManager/FMPFileSelectionManager.h

--- a/FMPFeedbackForm/include/FMPHostApplication.h
+++ b/FMPFeedbackForm/include/FMPHostApplication.h
@@ -1,0 +1,1 @@
+../Sources/Model/HostApplication/FMPHostApplication.h

--- a/FMPFeedbackForm/include/FMPInterfaceSettings+ObservableProperties.h
+++ b/FMPFeedbackForm/include/FMPInterfaceSettings+ObservableProperties.h
@@ -1,0 +1,1 @@
+../Sources/Model/Settings/FMPInterfaceSettings+ObservableProperties.h

--- a/FMPFeedbackForm/include/FMPInterfaceSettings.h
+++ b/FMPFeedbackForm/include/FMPInterfaceSettings.h
@@ -1,0 +1,1 @@
+../Sources/Model/Settings/FMPInterfaceSettings.h

--- a/FMPFeedbackForm/include/FMPLeftFlowLayout.h
+++ b/FMPFeedbackForm/include/FMPLeftFlowLayout.h
@@ -1,0 +1,1 @@
+../Sources/Utilities/FMPLeftFlowLayout.h

--- a/FMPFeedbackForm/include/FMPLocalizedString.h
+++ b/FMPFeedbackForm/include/FMPLocalizedString.h
@@ -1,0 +1,1 @@
+../Sources/Utilities/FMPLocalizedString.h

--- a/FMPFeedbackForm/include/FMPMainViewController.h
+++ b/FMPFeedbackForm/include/FMPMainViewController.h
@@ -1,0 +1,1 @@
+../Sources/ViewControllers/FMPMainViewController.h

--- a/FMPFeedbackForm/include/FMPMaskedImageView.h
+++ b/FMPFeedbackForm/include/FMPMaskedImageView.h
@@ -1,0 +1,1 @@
+../Sources/Views/FMPMaskedImageView.h

--- a/FMPFeedbackForm/include/FMPSystemInfo.h
+++ b/FMPFeedbackForm/include/FMPSystemInfo.h
@@ -1,0 +1,1 @@
+../Sources/Model/SystemProfileProvider/FMPSystemInfo.h

--- a/FMPFeedbackForm/include/FMPSystemProfileProvider.h
+++ b/FMPFeedbackForm/include/FMPSystemProfileProvider.h
@@ -1,0 +1,1 @@
+../Sources/Model/SystemProfileProvider/FMPSystemProfileProvider.h

--- a/FMPFeedbackForm/include/FMPSystemProfileViewController.h
+++ b/FMPFeedbackForm/include/FMPSystemProfileViewController.h
@@ -1,0 +1,1 @@
+../Sources/ViewControllers/FMPSystemProfileViewController.h

--- a/FMPFeedbackForm/include/FMPTextControl.h
+++ b/FMPFeedbackForm/include/FMPTextControl.h
@@ -1,0 +1,1 @@
+../Sources/Views/TextControls/FMPTextControl.h

--- a/FMPFeedbackForm/include/FMPTextControlValidationContainer.h
+++ b/FMPFeedbackForm/include/FMPTextControlValidationContainer.h
@@ -1,0 +1,1 @@
+../Sources/Views/TextControls/FMPTextControlValidationContainer.h

--- a/FMPFeedbackForm/include/FMPTextField.h
+++ b/FMPFeedbackForm/include/FMPTextField.h
@@ -1,0 +1,1 @@
+../Sources/Views/TextControls/FMPTextField.h

--- a/FMPFeedbackForm/include/FMPTextFieldCell.h
+++ b/FMPFeedbackForm/include/FMPTextFieldCell.h
@@ -1,0 +1,1 @@
+../Sources/Views/FMPTextFieldCell.h

--- a/FMPFeedbackForm/include/FMPTextFieldWrapper.h
+++ b/FMPFeedbackForm/include/FMPTextFieldWrapper.h
@@ -1,0 +1,1 @@
+../Sources/Views/TextControls/FMPTextFieldWrapper.h

--- a/FMPFeedbackForm/include/FMPTextView.h
+++ b/FMPFeedbackForm/include/FMPTextView.h
@@ -1,0 +1,1 @@
+../Sources/Views/TextControls/FMPTextView.h

--- a/FMPFeedbackForm/include/FMPTextViewScroller.h
+++ b/FMPFeedbackForm/include/FMPTextViewScroller.h
@@ -1,0 +1,1 @@
+../Sources/Views/TextControls/FMPTextViewScroller.h

--- a/FMPFeedbackForm/include/FMPTransparentSpinner.h
+++ b/FMPFeedbackForm/include/FMPTransparentSpinner.h
@@ -1,0 +1,1 @@
+../Sources/Views/FMPTransparentSpinner.h

--- a/FMPFeedbackForm/include/FMPValidatableTextControlContainer.h
+++ b/FMPFeedbackForm/include/FMPValidatableTextControlContainer.h
@@ -1,0 +1,1 @@
+../Sources/Views/TextControls/FMPValidatableTextControlContainer.h

--- a/FMPFeedbackForm/include/FMPValidatedParameters.h
+++ b/FMPFeedbackForm/include/FMPValidatedParameters.h
@@ -1,0 +1,1 @@
+../Sources/Model/FeedbackSender/FMPValidatedParameters.h

--- a/FMPFeedbackForm/include/FMPWindow.h
+++ b/FMPFeedbackForm/include/FMPWindow.h
@@ -1,0 +1,1 @@
+../Sources/WindowController/FMPWindow.h

--- a/FMPFeedbackForm/include/FMPZendeskFeedbackSender.h
+++ b/FMPFeedbackForm/include/FMPZendeskFeedbackSender.h
@@ -1,0 +1,1 @@
+../Sources/Model/FeedbackSender/FMPZendeskFeedbackSender.h

--- a/FMPFeedbackForm/include/NSColor+FMPExtensions.h
+++ b/FMPFeedbackForm/include/NSColor+FMPExtensions.h
@@ -1,0 +1,1 @@
+../Sources/Extensions/NSColor+FMPExtensions.h

--- a/FMPFeedbackForm/include/NSError+FMPExtensions.h
+++ b/FMPFeedbackForm/include/NSError+FMPExtensions.h
@@ -1,0 +1,1 @@
+../Sources/Extensions/NSError+FMPExtensions.h

--- a/FMPFeedbackForm/include/NSImage+FMPExtensions.h
+++ b/FMPFeedbackForm/include/NSImage+FMPExtensions.h
@@ -1,0 +1,1 @@
+../Sources/Extensions/NSImage+FMPExtensions.h

--- a/FMPFeedbackForm/include/NSObject+FMPExtensions.h
+++ b/FMPFeedbackForm/include/NSObject+FMPExtensions.h
@@ -1,0 +1,1 @@
+../Sources/Extensions/NSObject+FMPExtensions.h

--- a/FMPFeedbackForm/include/NSString+FMPExtensions.h
+++ b/FMPFeedbackForm/include/NSString+FMPExtensions.h
@@ -1,0 +1,1 @@
+../Sources/Extensions/NSString+FMPExtensions.h

--- a/FMPFeedbackForm/include/NSTextField+FMPExtensions.h
+++ b/FMPFeedbackForm/include/NSTextField+FMPExtensions.h
@@ -1,0 +1,1 @@
+../Sources/Extensions/NSTextField+FMPExtensions.h

--- a/FMPFeedbackForm/include/NSView+FMPExtensions.h
+++ b/FMPFeedbackForm/include/NSView+FMPExtensions.h
@@ -1,0 +1,1 @@
+../Sources/Extensions/NSView+FMPExtensions.h

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "FMPFeedbackForm",
+    defaultLocalization: "en",
+    platforms: [
+        .macOS(.v10_12)
+    ],
+    products: [
+    .library(
+            name: "FMPFeedbackForm",
+            targets: ["FMPFeedbackForm"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "FMPFeedbackForm",
+            path: "FMPFeedbackForm",
+            exclude: ["Info.plist"],
+            resources: [.process("Resources")]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ FMPFeedbackForm is available through [Carthage](https://github.com/Carthage/Cart
 github "MacPaw/FMPFeedbackForm"
 ```
 
+### Swift Package Manager
+
+* Add package into Project settings -> Swift Packages
+
+If you want to use FMPFeedbackForm as dependency to another package, add following to your Package.swift:
+
+```
+dependencies: [
+    ...
+    .package(url: "https://github.com/MacPaw/FMPFeedbackForm", .upToNextMajor(from: "1.0.0"))
+],
+...
+targets: [
+    .target(
+        name: ...
+        dependencies: [
+            ...,
+            "FMPFeedbackForm"
+        ]
+    )
+]
+```
+
 ### Manual
 Clone this repository (or add it as a submodule) and drag the `FMPFeedbackForm.xcodedeproj` into your project in Xcode. 
 Then go to your target's General settings tab and add the `FMPFeedbackForm.framework`


### PR DESCRIPTION
Hi! :)

This PR adds support for installing FMPFeedbackForm via SPM. There are several gotchas I encountered, so here's a list what was done:

- SwiftPM requires a single folder for all Objective-C headers. It is not possible to have several folders. In order to satisfy this requirement, all headers were symlinked into `FMPFeedbackForm/include` directory.
- SwiftPM does not like angle-bracketed imports, so those were replaced with quoted ones. It does not affect how project builds using CocoaPods/Carthage or manually.
- SwiftPM defines it's own module for resources, so localized strings, color and image assets now have conditional code that uses `SWIFTPM_MODULE_BUNDLE` define to access correct bundle.
- Because `include` folder now contains all headers (symlinked), it was explicitly excluded from podspec file to prevent CocoaPods build failures. 
- Installation instructions have been added to Readme file

In the future, SwiftPM integration can break, if additional headers will be added or moved to different directory, as those would require updating symlinks. Script to synchronize symlinks would be nice here, but seems out of scope for this PR.