### PR TITLE
Fix SPM install issue

### DIFF
--- a/FMPFeedbackForm/FMPFeedbackForm.h
+++ b/FMPFeedbackForm/FMPFeedbackForm.h
@@ -6,16 +6,8 @@
 //  Copyright © 2020 MacPaw. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
-#import "FMPFeedbackParameter.h"
-#import "FMPFeedbackSender.h"
-#import "FMPZendeskFeedbackSender.h"
-#import "FMPFeedbackController.h"
-#import "FMPInterfaceSettings.h"
-#else
 #import <FMPFeedbackForm/FMPFeedbackParameter.h>
 #import <FMPFeedbackForm/FMPFeedbackSender.h>
 #import <FMPFeedbackForm/FMPZendeskFeedbackSender.h>
 #import <FMPFeedbackForm/FMPFeedbackController.h>
 #import <FMPFeedbackForm/FMPInterfaceSettings.h>
-#endif

--- a/FMPFeedbackForm/include/FMPFeedbackForm.h
+++ b/FMPFeedbackForm/include/FMPFeedbackForm.h
@@ -1,1 +1,0 @@
-../FMPFeedbackForm.h

--- a/FMPFeedbackForm/include/FMPFeedbackForm.h
+++ b/FMPFeedbackForm/include/FMPFeedbackForm.h
@@ -1,0 +1,14 @@
+//
+//  FMPFeedbackForm.h
+//  FMPFeedbackForm
+//
+//  Created by Anton Barkov on 21.01.2020.
+//  Copyright © 2020 MacPaw. All rights reserved.
+//
+
+// Imports For Swift Package Manager are required to be double-quoted.
+#import "FMPFeedbackParameter.h"
+#import "FMPFeedbackSender.h"
+#import "FMPZendeskFeedbackSender.h"
+#import "FMPFeedbackController.h"
+#import "FMPInterfaceSettings.h"


### PR DESCRIPTION
It turns out, that if you install library from branch using SPM, SWIFT_PACKAGE is defined for public headers, however if you install from tag(1.0.2 for example), SWIFT_PACKAGE is not defined for public headers, breaking compilation.

```
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "<redacted>/SourcePackages/checkouts/FMPFeedbackForm/FMPFeedbackForm/include/FMPFeedbackForm.h"

<redacted>/SourcePackages/checkouts/FMPFeedbackForm/FMPFeedbackForm/include/FMPFeedbackForm.h:16:9: error: 'FMPFeedbackForm/FMPFeedbackParameter.h' file not found
#import <FMPFeedbackForm/FMPFeedbackParameter.h>
```

To work around this limitation, I created separate FMPFeedbackForm.h file in include folder that uses quoted imports, and removed previous `if` from framework header, that uses angled imports.

Some useful links: 

- https://forums.swift.org/t/unable-to-compile-swift-package-when-used-in-xcode/36081
- https://github.com/firebase/firebase-ios-sdk/blob/master/HeadersImports.md#header-file-types-and-locations---for-header-file-creators