### PR TITLE
Fix Chinese string + add custom fields for Zendesk

### DIFF
--- a/FMPFeedbackForm.xcodeproj/project.pbxproj
+++ b/FMPFeedbackForm.xcodeproj/project.pbxproj
@@ -228,6 +228,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2F7EA5CB299A59F30072C0DE /* Zendesk */ = {
+			isa = PBXGroup;
+			children = (
+				2FD152AC23D6F11700EE0BC2 /* FMPZendeskFeedbackSender.h */,
+				2FD152AD23D6F11700EE0BC2 /* FMPZendeskFeedbackSender.m */,
+			);
+			path = Zendesk;
+			sourceTree = "<group>";
+		};
 		2FA47A7723F1D010005E4467 /* AttachmentItems */ = {
 			isa = PBXGroup;
 			children = (
@@ -352,9 +361,8 @@
 		2FD152AB23D6F0F700EE0BC2 /* FeedbackSender */ = {
 			isa = PBXGroup;
 			children = (
+				2F7EA5CB299A59F30072C0DE /* Zendesk */,
 				2FD1528023D6DE8E00EE0BC2 /* FMPFeedbackSender.h */,
-				2FD152AC23D6F11700EE0BC2 /* FMPZendeskFeedbackSender.h */,
-				2FD152AD23D6F11700EE0BC2 /* FMPZendeskFeedbackSender.m */,
 				2FE6B52824236298005C2EC2 /* FMPValidatedParameters.h */,
 				2FE6B52924236298005C2EC2 /* FMPValidatedParameters.m */,
 				2FFBFCEF23EC3D2000B41736 /* FMPFeedbackParameter.h */,

--- a/FMPFeedbackForm/Resources/zh-Hans.lproj/Localizable.strings
+++ b/FMPFeedbackForm/Resources/zh-Hans.lproj/Localizable.strings
@@ -34,7 +34,7 @@
 "Provide Feedback" = "提供反馈";
 
 /* Feedback form description. */
-"Please provide a detailed description of your problem, suggestion, bug-report or question so that we have a clear picture of your request and react to it with maximum effectiveness." = "请提供关于您问题的详细描述、建议、漏洞报告或者您的疑问，以便我们对您的诉求有了清晰的认识之后才能给您最有效的答覆。";
+"Please provide a detailed description of your problem, suggestion, bug-report or question so that we have a clear picture of your request and react to it with maximum effectiveness." = "请提供关于您问题的详细描述、建议、漏洞报告或者您的疑问，以便我们对您的诉求有了清晰的认识之后才能给您最有效的答复。";
 
 /* Feedback subject option. */
 "Feedback" = "反馈";

--- a/FMPFeedbackForm/Sources/Model/FeedbackSender/Zendesk/FMPZendeskFeedbackSender.h
+++ b/FMPFeedbackForm/Sources/Model/FeedbackSender/Zendesk/FMPZendeskFeedbackSender.h
@@ -21,6 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
                                authToken:(NSString *)authToken
                              productName:(NSString *)productName NS_DESIGNATED_INITIALIZER;
 
+/// Custom ticket fields that you can set up from Zendesk side.
+/// More info here: https://developer.zendesk.com/documentation/ticketing/managing-tickets/creating-and-updating-tickets/#setting-custom-field-values
+@property (nonatomic, copy) NSArray<NSDictionary<NSString *, id> *> *customFields;
+
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/FMPFeedbackForm/Sources/Model/FeedbackSender/Zendesk/FMPZendeskFeedbackSender.m
+++ b/FMPFeedbackForm/Sources/Model/FeedbackSender/Zendesk/FMPZendeskFeedbackSender.m
@@ -102,12 +102,20 @@ typedef void (^FMPUploadFilesCompletion)(NSError *_Nullable error, NSString *_Nu
                 [commentDict setObject:[NSArray arrayWithObject:uploadsToken] forKey:@"uploads"];
             }
             
+            // Custom fields
+            NSArray *customFields = @[];
+            if (self.customFields)
+            {
+                customFields = self.customFields;
+            }
+            
             // Prepare request
             NSDictionary *bodyDict = @{
                 @"request": @{
                         @"requester": [requesterDict copy],
                         @"subject": subject,
-                        @"comment": [commentDict copy]
+                        @"comment": [commentDict copy],
+                        @"custom_fields": customFields
                 }
             };
             NSError *jsonError = nil;


### PR DESCRIPTION
## Changes
- Fixed a typo in one Chinese localized string.
- Added a property for `FMPZendeskFeedbackSender` to be able to set values for custom form fields. These fields are set up in the Zendesk admin panel and have a static numeric identifier. To set values to these fields, simply do this:

```swift
zendeskSender.customFields = [["id": 929175, "value": "some value"], 
                              ["id": 185729, "value": ["other value", "blah"]]]
```