### PR TITLE
Fix SPM for Tuist

### DIFF
--- a/FMPFeedbackForm/Sources/Utilities/FMPBundleHelper.m
+++ b/FMPFeedbackForm/Sources/Utilities/FMPBundleHelper.m
@@ -8,6 +8,34 @@
 
 #import "FMPBundleHelper.h"
 
+// We need this check and declaration for Tuist because it does not generate SWIFTPM_MODULE_BUNDLE for objc SPM.
+#if SWIFT_PACKAGE && !(defined(SWIFTPM_MODULE_BUNDLE))
+
+NSBundle* SWIFTPM_MODULE_BUNDLE() {
+    NSString *bundleName = @"FMPFeedbackForm_FMPFeedbackForm";
+
+    NSArray<NSURL*> *candidates = @[
+        NSBundle.mainBundle.resourceURL,
+        [NSBundle bundleForClass:[FMPBundleHelper class]].resourceURL,
+        NSBundle.mainBundle.bundleURL
+    ];
+
+    for (NSURL* candiate in candidates) {
+        NSURL *bundlePath = [candiate URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.bundle", bundleName]];
+
+        NSBundle *bundle = [NSBundle bundleWithURL:bundlePath];
+        if (bundle != nil) {
+            return bundle;
+        }
+    }
+
+    @throw [[NSException alloc] initWithName:@"SwiftPMResourcesAccessor" reason:[NSString stringWithFormat:@"unable to find bundle named %@", bundleName] userInfo:nil];
+}
+
+#define SWIFTPM_MODULE_BUNDLE SWIFTPM_MODULE_BUNDLE()
+
+#endif
+
 @implementation FMPBundleHelper
 
 + (NSBundle *)currentBundle


### PR DESCRIPTION
## What
When adding this framework as an SPM dependency for Tuist, Tuist doesn't generate `SWIFTPM_MODULE_BUNDLE` for the Objc SPM package.
There is a link to related issues in Tuist https://github.com/tuist/tuist/issues/3785 and https://github.com/tuist/tuist/pull/4902.
So, to fix this problem I added the `SWIFTPM_MODULE_BUNDLE` implementation to `FMPBundleHelper`. That implementation is based on the swift-generated implementation in the file `TuistBundle+FMPFeedbackForm.swift`.

<img width="1840" alt="screenshot" src="https://user-images.githubusercontent.com/1204957/235912623-c63f75be-0d71-4d80-a4b3-5a7d658a81eb.png">
