### PR TITLE
fix: UI insets and window title

### DIFF
--- a/FMPFeedbackForm/Sources/Model/Settings/FMPInterfaceSettings.h
+++ b/FMPFeedbackForm/Sources/Model/Settings/FMPInterfaceSettings.h
@@ -52,6 +52,9 @@ NS_ASSUME_NONNULL_BEGIN
 ///             and want to prefill the form for him.
 @property (nonatomic, copy) NSString *defaultEmail;
 
+/// The form's window title.
+@property (nonatomic, copy) NSString *windowTitle;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FMPFeedbackForm/Sources/Model/Settings/FMPInterfaceSettings.m
+++ b/FMPFeedbackForm/Sources/Model/Settings/FMPInterfaceSettings.m
@@ -24,6 +24,7 @@
     settings.namePlaceholder = FMPLocalizedString(@"John Appleseed", @"Customer name field placeholder. Any generic name and surname specific to the language, nothing too funny though.");
     settings.emailPlaceholder = @"someone@somewhere.com";
     settings.detailsPlaceholder = FMPLocalizedString(@"Write your message here...", @"Feedback details field placeholder.");
+    settings.windowTitle = @"";
     
     return settings;
 }

--- a/FMPFeedbackForm/Sources/ViewControllers/FMPMainViewController.m
+++ b/FMPFeedbackForm/Sources/ViewControllers/FMPMainViewController.m
@@ -266,11 +266,23 @@ static CGFloat textControlFontSize = 13.0;
     self.subjectButton = [NSPopUpButton fmp_newAutoLayout];
     self.subjectButton.font = [NSFont systemFontOfSize:13.0];
     [self.formContainer addSubview:self.subjectButton];
+
     [NSLayoutConstraint activateConstraints:@[
-        [self.subjectButton.topAnchor constraintEqualToAnchor:self.subtitleLabel.bottomAnchor constant:14],
-        [self.subjectButton.leftAnchor constraintEqualToAnchor:self.formContainer.leftAnchor],
-        [self.subjectButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor]
+        [self.subjectButton.topAnchor constraintEqualToAnchor:self.subtitleLabel.bottomAnchor constant:14]
     ]];
+    if (@available(macOS 11.0, *))
+    {
+        [NSLayoutConstraint activateConstraints:@[
+            [self.subjectButton.leftAnchor constraintEqualToAnchor:self.formContainer.leftAnchor constant:0.5],
+            [self.subjectButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor constant:-0.5]
+        ]];
+    } else
+    {
+        [NSLayoutConstraint activateConstraints:@[
+            [self.subjectButton.leftAnchor constraintEqualToAnchor:self.formContainer.leftAnchor],
+            [self.subjectButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor]
+        ]];
+    }
 }
 
 - (void)setupNameField
@@ -417,11 +429,23 @@ static CGFloat textControlFontSize = 13.0;
     [self.sendButton setTitle:self.sendButtonDefaultTitle];
     [self.sendButton setBezelStyle:NSBezelStyleRounded];
     [self.formContainer addSubview:self.sendButton];
+
     [NSLayoutConstraint activateConstraints:@[
-        [self.sendButton.topAnchor constraintEqualToAnchor:self.systemProfileCheckbox.bottomAnchor constant:15],
-        [self.sendButton.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor],
-        [self.sendButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor]
+        [self.sendButton.topAnchor constraintEqualToAnchor:self.systemProfileCheckbox.bottomAnchor constant:15]
     ]];
+    if (@available(macOS 11.0, *))
+    {
+        [NSLayoutConstraint activateConstraints:@[
+            [self.sendButton.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor constant:-0.5],
+            [self.sendButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor constant:-0.5]
+        ]];
+    } else
+    {
+        [NSLayoutConstraint activateConstraints:@[
+            [self.sendButton.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor],
+            [self.sendButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor]
+        ]];
+    }
 }
 
 - (void)setupProgressSpinner

--- a/FMPFeedbackForm/Sources/ViewControllers/FMPMainViewController.m
+++ b/FMPFeedbackForm/Sources/ViewControllers/FMPMainViewController.m
@@ -273,8 +273,8 @@ static CGFloat textControlFontSize = 13.0;
     if (@available(macOS 11.0, *))
     {
         [NSLayoutConstraint activateConstraints:@[
-            [self.subjectButton.leftAnchor constraintEqualToAnchor:self.formContainer.leftAnchor constant:0.5],
-            [self.subjectButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor constant:-0.5]
+            [self.subjectButton.leftAnchor constraintEqualToAnchor:self.formContainer.leftAnchor constant:1],
+            [self.subjectButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor constant:-1]
         ]];
     } else
     {
@@ -436,8 +436,8 @@ static CGFloat textControlFontSize = 13.0;
     if (@available(macOS 11.0, *))
     {
         [NSLayoutConstraint activateConstraints:@[
-            [self.sendButton.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor constant:-0.5],
-            [self.sendButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor constant:-0.5]
+            [self.sendButton.bottomAnchor constraintEqualToAnchor:self.formContainer.bottomAnchor constant:-1],
+            [self.sendButton.rightAnchor constraintEqualToAnchor:self.formContainer.rightAnchor constant:-1]
         ]];
     } else
     {

--- a/FMPFeedbackForm/Sources/WindowController/FMPFeedbackController.m
+++ b/FMPFeedbackForm/Sources/WindowController/FMPFeedbackController.m
@@ -54,6 +54,7 @@
                                                                          fileSelectionManager:fileSelectionMaganer
                                                                         systemProfileProvider:self.systemProfileProvider
                                                                                      settings:settings];
+    self.window.title = settings.windowTitle;
     mainViewController.delegate = self;
     self.contentViewController = mainViewController;
 }


### PR DESCRIPTION
## Changes
- [x] There was a bug since macOS 11 in the form with the insets of subjectButton and sendButton, the edges of them were a little cut.
- [x] Provide possibility to add window title to the form if it's required. 

## Impacted areas
UI elements of the feedback form. 

## How to test
- Open macOS 10.15 (min target) - insets and edges of these elements should the correct.
- Open macOS 11 (and higher) - insets and edges of these elements should be fixed. 

## Screenshots
**Before:** 
![image](https://github.com/MacPaw/FMPFeedbackForm/assets/43824249/ae77ac3e-2cca-4347-b9ec-585d5bd4039e)

**After:** 
![CleanShot 2023-08-25 at 15 46 49@2x](https://github.com/MacPaw/FMPFeedbackForm/assets/43824249/323c52d3-ebb6-45ac-a64e-9a086e058cef)

## Links
**Jira Task:** [SET-1236](https://macpaw.atlassian.net/browse/SET-1236)

## Additional notes

[SET-1236]: https://macpaw.atlassian.net/browse/SET-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ