### PR TITLE
docs: improve contributing guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ fastlane/test_output
 
 iOSInjectionProject/
 
+/.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+## How to Contribute to FMPFeedbackForm
+
+Thanks for stopping by — we appreciate your interest in helping out!
+
+**[FMPFeedbackForm](https://github.com/MacPaw/FMPFeedbackForm)** is an open source Objective-C framework that makes it easy to add a feedback form to macOS apps. It comes with Zendesk integration, system profiling, and localization support.
+
+---
+
+### Found a Bug?
+
+Great! Here's how to help:
+- Check if it's already [reported](https://github.com/MacPaw/FMPFeedbackForm/issues).  
+- If not, [open a new issue](https://github.com/MacPaw/FMPFeedbackForm/issues/new) with clear steps to reproduce and a minimal example if possible.  
+- **Security issue?** Please contact us privately — don't open a public issue.
+
+---
+
+### Want to Contribute Code?
+
+Excellent — we'd love your help!
+
+#### Before You Start
+- Make sure your environment is set up
+- Review open issues and discussions
+- Check our style and testing guidelines
+
+#### Steps
+1. Fork the repo
+2. Make your changes:
+   - Follow our [code style](#code-style)
+   - Write tests if needed
+   - Keep commits focused and clear (use conventional commits)
+3. Open a Pull Request:
+   - Briefly explain what you changed and why
+   - Link to any related issues
+
+💡 Tip: Test your changes using the **[FMPDemoApp](https://github.com/MacPaw/FMPFeedbackForm/discussions/new/choose)**.
+
+---
+
+### Improve Docs
+
+Clear docs help everyone — from first-time users to experienced developers.
+
+You can:
+- Fix typos or outdated info
+- Update code examples or comments
+- Help with UI translations (we support 11 languages!)
+
+---
+
+### Have Questions?
+
+Not sure where to start?  
+[Open a discussion](https://github.com/MacPaw/FMPFeedbackForm/discussions/new/choose)
+
+---
+
+### Code Style
+
+- Stick to the current structure (Objective-C, Xcode layout)
+- Use clear and descriptive names
+- Write meaningful commit messages
+- Avoid purely cosmetic changes (e.g., reformatting without functional impact)
+
+---
+
+**Thanks for being part of the community!**  
+— *The MacPaw Team*


### PR DESCRIPTION
### Summary
- Added a `CONTRIBUTING.md` file to help new contributors get started with contributing to FMPFeedbackForm.
- Updated `.gitignore` to exclude `.idea` directory used by JetBrains IDEs.

### Motivation
Clear contribution guidelines make it easier for newcomers to report bugs, suggest improvements, and submit pull requests